### PR TITLE
Patch keyboard overlap and nested scroll bugs

### DIFF
--- a/src/components/NestableScrollContainer.tsx
+++ b/src/components/NestableScrollContainer.tsx
@@ -7,6 +7,7 @@ import {
   useSafeNestableScrollContainerContext,
 } from "../context/nestableScrollContainerContext";
 import { useStableCallback } from "../hooks/useStableCallback";
+import useKeyboardListener from "../hooks/useKeyboardListener";
 
 const AnimatedScrollView = Animated.createAnimatedComponent(ScrollView);
 
@@ -18,6 +19,8 @@ function NestableScrollContainerInner(props: ScrollViewProps) {
     scrollableRef,
     outerScrollEnabled,
   } = useSafeNestableScrollContainerContext();
+
+  useKeyboardListener();
 
   const onScroll = useAnimatedScrollHandler({
     onScroll: ({ contentOffset }) => {

--- a/src/hooks/useKeyboardListener.tsx
+++ b/src/hooks/useKeyboardListener.tsx
@@ -1,0 +1,62 @@
+import { useCallback, useEffect } from "react";
+import {
+  Dimensions,
+  Keyboard,
+  KeyboardEvent,
+  KeyboardEventName,
+  Platform,
+  TextInput,
+} from "react-native";
+import { useSafeNestableScrollContainerContext } from "../context/nestableScrollContainerContext";
+
+const shouldTrackKeyboard = Platform.OS === "ios";
+
+function useKeyboardEvent(
+  eventType: KeyboardEventName,
+  callback: ((e: KeyboardEvent) => void) | null
+) {
+  useEffect(() => {
+    if (!callback) {
+      return;
+    }
+
+    const listener = Keyboard.addListener(eventType, callback);
+    return () => listener.remove();
+  }, [eventType, callback]);
+}
+
+export default function useKeyboardListener() {
+  const {
+    outerScrollOffset,
+    scrollableRef,
+  } = useSafeNestableScrollContainerContext();
+
+  const onKeyboardShown = useCallback((e: KeyboardEvent) => {
+    const keyboardHeight = e.endCoordinates.height;
+    const currentInput = TextInput.State.currentlyFocusedInput();
+
+    if (!currentInput) {
+      return;
+    }
+
+    currentInput.measure((originX, originY, width, height, pageX, pageY) => {
+      const yFromTop = pageY;
+      const componentHeight = height;
+      const screenHeight = Dimensions.get("window").height;
+      const yFromBottom = screenHeight - yFromTop - componentHeight;
+      const hiddenOffset = keyboardHeight - yFromBottom;
+      const margin = 32;
+      if (hiddenOffset > 0) {
+        scrollableRef.current?.scrollTo({
+          animated: true,
+          y: outerScrollOffset.value + hiddenOffset + margin,
+        });
+      }
+    });
+  }, []);
+
+  useKeyboardEvent(
+    "keyboardDidShow",
+    shouldTrackKeyboard ? onKeyboardShown : null
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ import {
   ViewStyle,
 } from "react-native";
 import { useAnimatedValues } from "./context/animatedValueContext";
-import { FlatList } from "react-native-gesture-handler";
+import { FlatList, TapGesture } from "react-native-gesture-handler";
 import Animated, {
   AnimateProps,
   WithSpringConfig,
@@ -63,7 +63,7 @@ export type RenderPlaceholder<T> = (params: {
 export type RenderItemParams<T> = {
   item: T;
   getIndex: () => number | undefined; // This is technically a "last known index" since cells don't necessarily rerender when their index changes
-  drag: () => void;
+  tapGesture: TapGesture;
   isActive: boolean;
 };
 


### PR DESCRIPTION
# Intro
This PR patches a couple of bugs that I've run into with the `react-native-draggable-flatlist` package.

## Use case and demo
I'm building a recipe editor UI with a feature for drag-and-drop reordering ingredients and instructions.

https://github.com/CarterSimonson/react-native-draggable-flatlist/assets/31598368/eaf49342-e18d-4a6a-beb7-2d97ab192ae8

# Bugs patched
## Scroll is broken in NestableScrollContainer
There's an open issue in the repo for this -> https://github.com/computerjazz/react-native-draggable-flatlist/issues/497

The workaround that I was able to find is:
- Update the `PanHandler` in `DraggableFlatList` to utilize an `enabled` state.
  - Set the pan handler to "manual activation" mode
- Compose a simultaneous `tapGesture` that replaces the "drag" function returned to list items
  - Set the shared `enabled` state to true when the `tapGesture` is pressed down.
  - Reset `enabled` to false on press up.

I initially tried controlling the `enabled` state from within the `drag` function but was getting some gnarly race conditions.

This results in the following behavior:
- If the user attempts to drag without triggering the `tapGesture`, the `panGesture` will fail and allow the regular scroll event.
- If the user drags on the tappable area (the drag icon for me in this case), the `tapGesture` will fire simultaneously and set the `enabled` state to true. The `panGesture` will activate and track the pan events.

Here's what that looks like within the consuming application:
```
  // The `drag` handler has been replaced by `tapGesture`
  function renderItem({ item, getIndex, tapGesture }: RenderItemParams<KeyedString>) {
    const index = getIndex();

    const right = (
      <GestureDetector gesture={tapGesture}>
        <DragIcon />
      </GestureDetector>
    );

    if (index !== undefined) {
      return (
        <InputListItem
          value={item.value}
          onChangeText={(value) => updateIngredient(value, index)}
          onBlur={() => onBlur(index)}
          right={right}
        />
      );
    }
  }
```

## Inputs are not keyboard aware
I found that neither [react-native-keyboard-aware-scroll-view](https://www.npmjs.com/package/react-native-keyboard-aware-scroll-view) or [KeyboardAvoidingView](https://reactnative.dev/docs/keyboardavoidingview) were compatible with the `NestableScrollContainer`.

This is worked around by the `useKeyboardListener` hook that is introduced in this PR. It listens to keyboard events and automatically scrolls to prevent the input from being hidden. Note that this only seemed to be necessary on iOS.